### PR TITLE
Toggleable auto-catch and revolvers

### DIFF
--- a/code/datums/components/magazine_catcher.dm
+++ b/code/datums/components/magazine_catcher.dm
@@ -43,4 +43,6 @@
 /datum/component/magazine_catcher/proc/try_to_catch_magazine(datum/source, obj/item/mag)
 	if(!storage.can_be_inserted(mag, FALSE))
 		return FALSE
+	if(!storage.auto_catch)
+		return FALSE
 	return storage.handle_item_insertion(mag, TRUE)

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -101,6 +101,16 @@
 		underlays -= holstered_item_underlay
 		QDEL_NULL(holstered_item_underlay)
 
+/obj/item/storage/holster/belt/verb/toggle_auto_catch()
+	set name = "Toggle Auto Catching Magazines"
+	set category = "Object"
+	auto_catch = !auto_catch
+	if(!auto_catch)
+		to_chat(usr, "Auto catching disabled.")
+	else
+		to_chat(usr, "Auto catching enabled.")
+
+
 /obj/item/storage/holster/do_quick_equip(mob/user) //Will only draw the specific holstered item, not ammo etc.
 	if(!holstered_item)
 		return FALSE
@@ -722,6 +732,8 @@
 /obj/item/storage/holster/belt/revolver/Initialize(mapload, ...)
 	. = ..()
 	AddComponent(/datum/component/tac_reload_storage)
+	AddComponent(/datum/component/magazine_catcher)
+	AddComponent(/datum/component/easy_restock)
 
 /obj/item/storage/holster/belt/revolver/t457
 	name = "\improper T457 pattern revolver holster rig"

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -78,6 +78,8 @@
 	var/refill_sound = null
 	///Flags for specifically storage items
 	var/flags_storage = NONE
+	///Auto catching empty magazines: 0 - disabled, 1 - enabled
+	var/obj/item/storage/holster/belt/pistol/auto_catch = 1
 
 /obj/item/storage/MouseDrop(atom/over_object)
 	if(!ishuman(usr))
@@ -622,6 +624,15 @@
 		to_chat(usr, "Clicking [src] with an empty hand now puts the last stored item in your hand.")
 	else
 		to_chat(usr, "Clicking [src] with an empty hand now opens the pouch storage menu.")
+
+/obj/item/storage/holster/belt/pistol/verb/toggle_auto_catch()
+	set name = "Toggle Auto Catching Empty Magazines"
+	set category = "Object"
+	auto_catch = !auto_catch
+	if(!auto_catch)
+		to_chat(usr, "Auto catching disabled.")
+	else
+		to_chat(usr, "Auto catching enabled.")
 
 /obj/item/storage/proc/quick_empty(atom/dest_object, mob/user)
 	if(!user.CanReach(dest_object) || !user.CanReach(src))

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -79,7 +79,7 @@
 	///Flags for specifically storage items
 	var/flags_storage = NONE
 	///Auto catching empty magazines: 0 - disabled, 1 - enabled
-	var/obj/item/storage/holster/belt/pistol/auto_catch = 1
+	var/auto_catch = 1
 
 /obj/item/storage/MouseDrop(atom/over_object)
 	if(!ishuman(usr))
@@ -624,15 +624,6 @@
 		to_chat(usr, "Clicking [src] with an empty hand now puts the last stored item in your hand.")
 	else
 		to_chat(usr, "Clicking [src] with an empty hand now opens the pouch storage menu.")
-
-/obj/item/storage/holster/belt/pistol/verb/toggle_auto_catch()
-	set name = "Toggle Auto Catching Magazines"
-	set category = "Object"
-	auto_catch = !auto_catch
-	if(!auto_catch)
-		to_chat(usr, "Auto catching disabled.")
-	else
-		to_chat(usr, "Auto catching enabled.")
 
 /obj/item/storage/proc/quick_empty(atom/dest_object, mob/user)
 	if(!user.CanReach(dest_object) || !user.CanReach(src))

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -626,7 +626,7 @@
 		to_chat(usr, "Clicking [src] with an empty hand now opens the pouch storage menu.")
 
 /obj/item/storage/holster/belt/pistol/verb/toggle_auto_catch()
-	set name = "Toggle Auto Catching Empty Magazines"
+	set name = "Toggle Auto Catching Magazines"
 	set category = "Object"
 	auto_catch = !auto_catch
 	if(!auto_catch)

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -95,6 +95,7 @@
 		S.remove_from_storage(new_magazine, get_turf(user), user)
 	user.put_in_any_hand_if_possible(new_magazine)
 	reload(new_magazine, user)
+	SEND_SIGNAL(user, COMSIG_MAGAZINE_DROP, new_magazine) //SEND_SIGNAL in reload wont do anything for revolvers because of ammo_magazine/handful ejecting. Putting it here solve this problem but it's kinda weird
 	if(!do_after(user, tac_reload_time * 0.2, IGNORE_USER_LOC_CHANGE, new_magazine) && loc == user)
 		return
 	unique_gun_close(user)


### PR DESCRIPTION
## `Основные изменения`
Револьверным ремням добавлены аналогичные пистолетным функции сброса использованных барабанов внутрь и пополнение этих же барабанов коробками при нажатии ПКМ. Также сам сброс стал отключаемым/включаемым в меню контекстном меню (шифт+ПКМ по ремню -> Toggle Auto Catching Magazines).
<!-- Опишите свой пулл реквест. -->

## `Как это улучшит игру`
Клёвая фишка перекочевала для револьверных ремней, а плюсом навалилась возможность её отключать при желании. Минусы - возможно немного насрано говнокодом. 
<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
add: Добавлена возможность отключения/включения авто-сброса магазинов/барабанов в ремень.
add: Авто-сброс и быстрое пополнение коробками доступно и для револьверных ремней.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
